### PR TITLE
calling transport.keep_alive to prevent socket closed / connection dropped error

### DIFF
--- a/auto_backup/backup_scheduler.py
+++ b/auto_backup/backup_scheduler.py
@@ -174,6 +174,8 @@ password=passwordLogin)
                     #Connect with external server over SFTP
                     srv = pysftp.Connection(host=ipHost, username=usernameLogin,
 password=passwordLogin)
+                    #set keepalive to prevent socket closed / connection dropped error
+                    srv._transport.set_keepalive(30)
                     #Move to the correct directory on external server. If the user made a typo in his path with multiple slashes (/odoo//backups/) it will be fixed by this regex.
                     pathToWriteTo = re.sub('([/]{2,5})+','/',pathToWriteTo)
                     print(pathToWriteTo)


### PR DESCRIPTION
Hello,

i made this change in order to fix a annoying bug which prevents a successfull backup with oddly configured ssh/sftp servers, and i hope it will be useful :)