### PR TITLE
[IMP]auto_backup:add backup type support.

### DIFF
--- a/auto_backup/bkp_conf_view.xml
+++ b/auto_backup/bkp_conf_view.xml
@@ -14,6 +14,7 @@
 						<field name="host" colspan="2"/>
 						<field name="name" />
 						<field name="port" />
+						<field name="backup_type"/>
 						<field name="bkp_dir" />
 						<field name="autoremove" />
 						<field name="daystokeep" attrs="{'invisible': [('autoremove','=',False)]}"/>


### PR DESCRIPTION
Add backup type field:backup_type, now you can choice backup type between zip and dump. sometimes the attachment file is really huge, we don't want backup it every time, add type support make backup much flexible.