### PR TITLE
better backup name

### DIFF
--- a/auto_backup/models/db_backup.py
+++ b/auto_backup/models/db_backup.py
@@ -144,7 +144,7 @@ class db_backup(models.Model):
                 except:
                     raise
                 #Create name for dumpfile.
-                bkp_file='%s_%s.%s' % (time.strftime('%d_%m_%Y_%H_%M_%S'),rec.name, rec.backup_type)
+                bkp_file='%s_%s.%s' % (time.strftime('%Y_%m_%d_%H_%M_%S'),rec.name, rec.backup_type)
                 file_path = os.path.join(rec.folder,bkp_file)
                 uri = 'http://' + rec.host + ':' + rec.port
                 conn = xmlrpclib.ServerProxy(uri + '/xmlrpc/db')


### PR DESCRIPTION
Using dates in ISO format (YYYY-MM-DD) allows you to easily order multiple backups. Alphabetic order and date order match.