### PR TITLE
More compatible isfile check

### DIFF
--- a/auto_backup/models/db_backup.py
+++ b/auto_backup/models/db_backup.py
@@ -19,6 +19,7 @@ import time
 import base64
 import socket
 
+import stat
 
 try:
     import paramiko
@@ -246,7 +247,7 @@ class db_backup(models.Model):
                             # If the file is older than the days_to_keep_sftp (the days to keep that the user filled in on the Odoo form it will be removed.
                             if delta.days >= rec.days_to_keep_sftp:
                                 # Only delete files, no directories!
-                                if sftp.isfile(fullpath) and (".dump" in file or '.zip' in file):
+                                if stat.S_ISREG(sftp.stat(fullpath).st_mode) and (".dump" in file or '.zip' in file):
                                     _logger.info("Delete too old file from SFTP servers: " + file)
                                     sftp.unlink(file)
                     # Close the SFTP session.


### PR DESCRIPTION
The current isfile check (which was removed from the 13.0 branch in 4a3f3f2) requires a recent version of the Paramiko library. A more compatible way to do the same check is by using stat. The check isn't completely useless, as also a directory could have (usually erroneously) a name containing .zip, so I suggest we make the check more compatible by using the stat method.