### PR TITLE
Better logging and exception cleanup for the SFTP connection

### DIFF
--- a/auto_backup/models/db_backup.py
+++ b/auto_backup/models/db_backup.py
@@ -232,6 +232,7 @@ class db_backup(models.Model):
                     # Navigate in to the correct folder.
                     sftp.chdir(pathToWriteTo)
 
+                    _logger.info("Checking expired files")
                     # Loop over all files in the directory from the back-ups.
                     # We will check the creation date of every back-up.
                     for file in sftp.listdir(pathToWriteTo):
@@ -252,7 +253,8 @@ class db_backup(models.Model):
                     # Close the SFTP session.
                     sftp.close()
                 except Exception as e:
-                    _logger.debug('Exception! We couldn\'t back up to the FTP server..')
+                    sftp.close()
+                    _logger.error('Exception! We couldn\'t back up to the FTP server..')
                     # At this point the SFTP backup failed. We will now check if the user wants
                     # an e-mail notification about this.
                     if rec.send_mail_sftp_fail:

--- a/auto_backup/models/db_backup.py
+++ b/auto_backup/models/db_backup.py
@@ -254,7 +254,7 @@ class db_backup(models.Model):
                     sftp.close()
                 except Exception as e:
                     sftp.close()
-                    _logger.error('Exception! We couldn\'t back up to the FTP server..')
+                    _logger.error('Exception! We couldn\'t back up to the FTP server. Here is what we got back instead: %s' % str(e))
                     # At this point the SFTP backup failed. We will now check if the user wants
                     # an e-mail notification about this.
                     if rec.send_mail_sftp_fail:

--- a/auto_backup/models/db_backup.py
+++ b/auto_backup/models/db_backup.py
@@ -232,7 +232,7 @@ class db_backup(models.Model):
                     # Navigate in to the correct folder.
                     sftp.chdir(pathToWriteTo)
 
-                    _logger.info("Checking expired files")
+                    _logger.debug("Checking expired files")
                     # Loop over all files in the directory from the back-ups.
                     # We will check the creation date of every back-up.
                     for file in sftp.listdir(pathToWriteTo):


### PR DESCRIPTION
We had a problem with the old backup cleanup not working properly because of #173. This left open SFTP connections since the exception handler doesn't close the connection. Additionally nothing was logged since the exception is currently logged on debug level. This PR fixes the logging and closes the SFTP connection on an exception.