### PR TITLE
Use modified timestamp instead of access timestamp for cleanup

### DIFF
--- a/auto_backup/models/db_backup.py
+++ b/auto_backup/models/db_backup.py
@@ -239,7 +239,7 @@ class db_backup(models.Model):
                             # Get the full path
                             fullpath = os.path.join(pathToWriteTo, file)
                             # Get the timestamp from the file on the external server
-                            timestamp = sftp.stat(fullpath).st_atime
+                            timestamp = sftp.stat(fullpath).st_mtime
                             createtime = datetime.datetime.fromtimestamp(timestamp)
                             now = datetime.datetime.now()
                             delta = now - createtime


### PR DESCRIPTION
Currently the old backups cleanup uses the last access timestamp for determining which files to remove. It would make more sense to use the modified timestamp instead.