### PR TITLE
Also close the SSH connection when quitting the backup job

### DIFF
--- a/auto_backup/models/db_backup.py
+++ b/auto_backup/models/db_backup.py
@@ -252,8 +252,13 @@ class db_backup(models.Model):
                                     sftp.unlink(file)
                     # Close the SFTP session.
                     sftp.close()
+                    s.close()
                 except Exception as e:
-                    sftp.close()
+                    try:
+                        sftp.close()
+                        s.close()
+                    except:
+                        pass
                     _logger.error('Exception! We couldn\'t back up to the FTP server. Here is what we got back instead: %s' % str(e))
                     # At this point the SFTP backup failed. We will now check if the user wants
                     # an e-mail notification about this.


### PR DESCRIPTION
We noticed that after #174 the sftp connections ceased to pile up, but there are still lots of SSH connections, one every day. Basically I missed the fact that the SFTP connection is opened by first opening an SSH connection, which is never closed. 

This patch adds closing the SSH connection to both the normal process and the exception handler.