### PR TITLE
Use Odoo external_dependencies

### DIFF
--- a/auto_backup/__manifest__.py
+++ b/auto_backup/__manifest__.py
@@ -33,4 +33,7 @@
         'views/backup_view.xml',
         'data/backup_data.xml',
     ],
+    'external_dependencies': {
+        'python': ['paramiko'],
+    },
 }

--- a/auto_backup/models/db_backup.py
+++ b/auto_backup/models/db_backup.py
@@ -13,13 +13,6 @@ import odoo
 import logging
 _logger = logging.getLogger(__name__)
 
-try:
-    import paramiko
-except ImportError:
-    raise ImportError(
-        'This module needs paramiko to automatically write backups to the FTP through SFTP. '
-        'Please install paramiko on your system. (sudo pip3 install paramiko)')
-
 
 class DbBackup(models.Model):
     _name = 'db.backup'


### PR DESCRIPTION
Incorporate Odoo's external_dependencies feature to gracefully handle the absence of paramiko, preventing module crashes.