### PR TITLE
16.0 : DeprecationWarning: Since 16.0, use `subprocess` directly.

### DIFF
--- a/auto_backup/__manifest__.py
+++ b/auto_backup/__manifest__.py
@@ -19,7 +19,7 @@
     'author': "Yenthe Van Ginneken",
     'website': "http://www.odoo.yenthevg.com",
     'category': 'Administration',
-    'version': '16.0.0.1',
+    'version': '16.0.0.2',
     'installable': True,
     'license': 'LGPL-3',
 

--- a/auto_backup/models/db_backup.py
+++ b/auto_backup/models/db_backup.py
@@ -5,11 +5,11 @@ import time
 import shutil
 import json
 import tempfile
-
+import subprocess
 from odoo import models, fields, api, tools, _
 from odoo.exceptions import Warning, AccessDenied
 import odoo
-
+from odoo.tools import find_pg_tool, exec_pg_environ
 import logging
 _logger = logging.getLogger(__name__)
 
@@ -276,7 +276,7 @@ class DbBackup(models.Model):
     def _take_dump(self, db_name, stream, model, backup_format='zip'):
         """Dump database `db` into file-like object `stream` if stream is None
         return a file object with the dump """
-
+        env = exec_pg_environ()
         cron_user_id = self.env.ref('auto_backup.backup_scheduler').user_id.id
         if self._name != 'db.backup' or cron_user_id != self.env.user.id:
             _logger.error('Unauthorized database operation. Backups should only be available from the cron job.')
@@ -284,8 +284,8 @@ class DbBackup(models.Model):
 
         _logger.info('DUMP DB: %s format %s', db_name, backup_format)
 
-        cmd = ['pg_dump', '--no-owner']
-        cmd.append(db_name)
+        cmd = [find_pg_tool('pg_dump'), '--no-owner', db_name]
+        # cmd.append(db_name)
 
         if backup_format == 'zip':
             with tempfile.TemporaryDirectory() as dump_dir:
@@ -297,7 +297,7 @@ class DbBackup(models.Model):
                     with db.cursor() as cr:
                         json.dump(self._dump_db_manifest(cr), fh, indent=4)
                 cmd.insert(-1, '--file=' + os.path.join(dump_dir, 'dump.sql'))
-                odoo.tools.exec_pg_command(*cmd)
+                subprocess.run(cmd, env=env, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT, check=True)
                 if stream:
                     odoo.tools.osutil.zip_dir(dump_dir, stream, include_dir=False, fnct_sort=lambda file_name: file_name != 'dump.sql')
                 else:
@@ -307,7 +307,7 @@ class DbBackup(models.Model):
                     return t
         else:
             cmd.insert(-1, '--format=c')
-            stdin, stdout = odoo.tools.exec_pg_command_pipe(*cmd)
+            stdout = subprocess.Popen(cmd, env=env, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE).stdout
             if stream:
                 shutil.copyfileobj(stdout, stream)
             else:


### PR DESCRIPTION
exec_pg_command and exec_pg_command_pip are deprecated in Odoo 16.0, use `subprocess` directly.