### PR TITLE
Odoo 18, Update backup_data.xml

### DIFF
--- a/auto_backup/data/backup_data.xml
+++ b/auto_backup/data/backup_data.xml
@@ -9,10 +9,7 @@
             <field name="priority">5</field>
             <field name="interval_number">1</field>
             <field name="interval_type">days</field>
-            <field name="numbercall">-1</field>
             <field name="active">False</field>
-            <field name="doall">False</field>
         </record>
     </data>
 </odoo>
-


### PR DESCRIPTION
In version 18, the numbercall and doall fields no longer exist.