### PR TITLE
[19.0][FIX] auto_backup: fix Odoo 19 compatibility issues

### DIFF
--- a/auto_backup/__manifest__.py
+++ b/auto_backup/__manifest__.py
@@ -19,7 +19,7 @@
     'author': "Yenthe Van Ginneken",
     'website': "http://www.odoo.yenthevg.com",
     'category': 'Administration',
-    'version': '17.0.0.1',
+    'version': '19.0.1.0.1',
     'installable': True,
     'license': 'LGPL-3',
     'module_type': 'official',

--- a/auto_backup/data/backup_data.xml
+++ b/auto_backup/data/backup_data.xml
@@ -9,9 +9,7 @@
             <field name="priority">5</field>
             <field name="interval_number">1</field>
             <field name="interval_type">days</field>
-            <field name="numbercall">-1</field>
             <field name="active">False</field>
-            <field name="doall">False</field>
         </record>
     </data>
 </odoo>

--- a/auto_backup/models/db_backup.py
+++ b/auto_backup/models/db_backup.py
@@ -8,6 +8,7 @@ import tempfile
 import subprocess
 from odoo import models, fields, api, tools, _
 from odoo.exceptions import UserError, AccessDenied
+from odoo.tools.misc import exec_pg_environ, find_pg_tool
 import odoo
 
 import logging
@@ -283,8 +284,8 @@ class DbBackup(models.Model):
 
         _logger.info('DUMP DB: %s format %s', db_name, backup_format)
 
-        cmd = [tools.find_pg_tool('pg_dump'), '--no-owner', db_name]
-        env = tools.exec_pg_environ()
+        cmd = [find_pg_tool('pg_dump'), '--no-owner', db_name]
+        env = exec_pg_environ()
 
         if backup_format == 'zip':
             with tempfile.TemporaryDirectory() as dump_dir:

--- a/auto_backup/security/user_groups.xml
+++ b/auto_backup/security/user_groups.xml
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data>
-        <record model="ir.module.category" id="module_management">
-            <field name="name">Auto backup access</field>
-            <field name="description">User access level for this module</field>
+        <record id="privilege_auto_backup" model="res.groups.privilege">
+            <field name="name">Auto Backup</field>
             <field name="sequence">3</field>
         </record>
 
         <record id="group_manager" model="res.groups">
             <field name="name">Manager</field>
-            <field name="category_id" ref="auto_backup.module_management"/>
+            <field name="privilege_id" ref="auto_backup.privilege_auto_backup"/>
         </record>
     </data>
 </odoo>

--- a/auto_backup/views/backup_view.xml
+++ b/auto_backup/views/backup_view.xml
@@ -69,26 +69,27 @@
     <record id="view_backup_config_tree" model="ir.ui.view">
         <field name="name">db.backup.tree</field>
         <field name="model">db.backup</field>
-        <field name="type">tree</field>
+        <field name="type">list</field>
         <field name="arch" type="xml">
-            <tree>
+            <list>
                 <field name='host'/>
                 <field name='port'/>
                 <field name='name'/>
                 <field name='folder'/>
                 <field name="autoremove"/>
                 <field name="sftp_host"/>
-            </tree>
+            </list>
         </field>
     </record>
 
     <record id="action_backup" model="ir.actions.act_window">
         <field name="name">Configure back-ups</field>
         <field name="res_model">db.backup</field>
-        <field name="view_mode">tree,form</field>
+        <field name="view_mode">list,form</field>
         <field name="view_id" ref="view_backup_config_tree"/>
+        <field name="group_ids" eval="[(4, ref('auto_backup.group_manager'))]"/>
     </record>
 
-    <menuitem id="auto_backup_menu" name="Back-ups" parent="base.menu_custom"/>
-    <menuitem parent="auto_backup_menu" action="action_backup" id="backup_conf_menu"/>
+    <menuitem id="auto_backup_menu" name="Back-ups" parent="base.menu_custom" groups="auto_backup.group_manager"/>
+    <menuitem parent="auto_backup_menu" action="action_backup" id="backup_conf_menu" groups="auto_backup.group_manager"/>
 </odoo>


### PR DESCRIPTION
- Replace res.groups category_id with privilege_id 
- Add res.groups.privilege for Auto Backup access 
- Update views from tree to list 
- Update actions and menus for Odoo 19 security changes 
- Remove deprecated cron fields 
- Update module version to 19.0.1.0.1